### PR TITLE
Avoid errors installing with Python 2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,10 @@ setup(
     long_description=long_description,
     long_description_content_type='text/markdown',
     url='https://github.com/DIRACGrid/tornado_m2crypto',
-    setup_requires=['setuptools_scm'],
+    setup_requires=[
+        'setuptools_scm<6; python_version < "3"',
+        'setuptools_scm; python_version >= "3"',
+    ],
     install_requires=[
         'enum34; python_version < "3.4"',
         'm2crypto',


### PR DESCRIPTION
It's a bit ugly but it avoid the issues with pip picking the wrong version of setuptools_scm for Python 2.