### PR TITLE
Handle SSL handshake state errors

### DIFF
--- a/tornado_m2crypto/m2iostream.py
+++ b/tornado_m2crypto/m2iostream.py
@@ -175,15 +175,18 @@ class M2IOStream(SSLIOStream):
                 res = self.socket.accept_ssl()
             else:
                 res = self.socket.connect_ssl()
+            # The err_num is used for the handshake state either way
+            err_num = self.socket.ssl_get_error(res)
             if res == 0:
-                # TODO: We should somehow get SSL_WANT_READ/WRITE here
-                #       and then set the correct flag, although it does
-                #       work as long as one of them gets set
-                self._handshake_reading = True
-                # self._handshake_writing = True
-                return
+                if err_num == ssl.SSL_ERROR_WANT_READ:
+                    self._handshake_reading = True
+                    return
+                elif err_num == ssl.SSL_ERROR_WANT_WRITE:
+                    self._handshake_writing = True
+                    return
+                else: # SSL_ERROR_ZERO_RETURN and others
+                    return self.close()
             if res < 0:
-                err_num = self.socket.ssl_get_error(res)
                 gen_log.error("Err: %s" % err_num)
                 gen_log.error("Err Str: %s" % Err.get_error_reason(err_num))
                 return self.close()


### PR DESCRIPTION
Hi,

We've found that since updating to a recent version of DIRACOS, our dirac-webapp-run process starts using 100% of a CPU after the access to the web interface (as described by @marianne013 on mattermost).

I've tracked this down to a change in the SSL handshake: It can now fail with the ERROR_ZERO_RETURN code that seemed to be unused before (connecting with firefox seems to generate one socket in this state most times). As it stands that causes the socket to get stuck in the _do_ssl_handshake step, going round continuously from the tornado epoll. This doesn't stop the server as other sockets are still also processed, but it causes high CPU utilisation.

This patch adds logic to handle the handshake result in more detail, which catches the SSL_ERROR_ZERO_RETURN case among others as well as solving an old TODO. This patch fixes the problem in our testing server side, although if used for a client socket it'd need another test (is that path ever actually used?).

Regards,
Simon
